### PR TITLE
Fix: 강의 업로드 후 홈페이지로 리다이렉트 resolve #32

### DIFF
--- a/src/pages/lecture-page/LectureUploadPage.tsx
+++ b/src/pages/lecture-page/LectureUploadPage.tsx
@@ -67,7 +67,7 @@ export default function LectureUploadPage() {
                     GetAccessToken(),
                 );
                 alert("영상 업로드 완료!");
-                navigate("/lectures");
+                navigate("/");
             } catch (err) {
                 alert("영상 업로드에 실패하였습니다");
             }


### PR DESCRIPTION
**✏️ 연관된 이슈**
Issue #32

**✏️ 작업 내용**
강의 업로드 후 홈페이지로 리다이렉트 되도록 수정